### PR TITLE
code generation for strongly-typed content types and their properties

### DIFF
--- a/src/CloudModelGenerator/ClassCodeGenerator.cs
+++ b/src/CloudModelGenerator/ClassCodeGenerator.cs
@@ -45,9 +45,43 @@ namespace CloudModelGenerator
                     )
             ).ToArray();
 
+            var classCodenameConstant = SyntaxFactory.FieldDeclaration(
+                            SyntaxFactory.VariableDeclaration(
+                                    SyntaxFactory.ParseTypeName("string"),
+                                    SyntaxFactory.SeparatedList(new[] {
+                                        SyntaxFactory.VariableDeclarator(
+                                            SyntaxFactory.Identifier("Codename"),
+                                            null,
+                                            SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression( SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(ClassDefinition.Codename)))
+                                        )
+                                    })
+                                )
+                            )
+                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.ConstKeyword));
+
+            var propertyCodenameConstants = ClassDefinition.PropertyCodenameConstants.Select(element =>
+                    SyntaxFactory.FieldDeclaration(
+                            SyntaxFactory.VariableDeclaration(
+                                    SyntaxFactory.ParseTypeName("string"),
+                                    SyntaxFactory.SeparatedList(new[] {
+                                        SyntaxFactory.VariableDeclarator(
+                                            SyntaxFactory.Identifier($"{TextHelpers.GetValidPascalCaseIdentifierName(element.Name)}Codename"),
+                                            null,
+                                            SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression( SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(element.Codename)))
+                                        )
+                                    })
+                                )
+                            )
+                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.ConstKeyword))
+            ).ToArray();
+
             var classDeclaration = SyntaxFactory.ClassDeclaration(ClassDefinition.ClassName)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PartialKeyword))
+                .AddMembers(classCodenameConstant)
+                .AddMembers(propertyCodenameConstants)
                 .AddMembers(properties);
 
             var description = SyntaxFactory.Comment(

--- a/src/CloudModelGenerator/ClassDefinition.cs
+++ b/src/CloudModelGenerator/ClassDefinition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using KenticoCloud.Delivery;
+using System;
 using System.Collections.Generic;
 
 namespace CloudModelGenerator
@@ -7,7 +8,10 @@ namespace CloudModelGenerator
     {
         public List<Property> Properties { get; } = new List<Property>();
 
+        public List<ContentElement> PropertyCodenameConstants { get; } = new List<ContentElement>();
+
         public string ClassName { get; }
+
         public string Codename { get; }
 
         public ClassDefinition(string codeName)
@@ -26,6 +30,16 @@ namespace CloudModelGenerator
             Properties.Add(property);
         }
 
+        public void AddPropertyCodenameConstant(ContentElement element)
+        {
+            if (PropertyCodenameConstantIsAlreadyPresent(element))
+            {
+                throw new InvalidOperationException($"Property with code name '{element.Codename}' is already included. Can't add two members with the same code name.");
+            }
+
+            PropertyCodenameConstants.Add(element);
+        }
+
         public void AddSystemProperty()
         {
             AddProperty(new Property("system", "ContentItemSystemAttributes"));
@@ -34,6 +48,11 @@ namespace CloudModelGenerator
         private bool PropertyIsAlreadyPresent(Property property)
         {
             return Properties.Exists(e => e.Identifier == property.Identifier);
+        }
+
+        private bool PropertyCodenameConstantIsAlreadyPresent(ContentElement element)
+        {
+            return PropertyCodenameConstants.Exists(e => e.Codename == element.Codename);
         }
     }
 }

--- a/src/CloudModelGenerator/CodeGenerator.cs
+++ b/src/CloudModelGenerator/CodeGenerator.cs
@@ -92,6 +92,7 @@ namespace CloudModelGenerator
                 try
                 {
                     var property = Property.FromContentType(element.Codename, element.Type);
+                    classDefinition.AddPropertyCodenameConstant(element);
                     classDefinition.AddProperty(property);
                 }
                 catch (InvalidOperationException)


### PR DESCRIPTION
Implemented code generation for strongly-typed content types and their properties in order to get rid of magic strings when querying. This will also prevent sudden breaking changes when someone changes a content type in Kentico Cloud. Regenerating the classes will cause a broken build and it informs every developer about possible changes before the web application is deployed to any target environment.