### PR TITLE
Use an appSettings.json file to allow users to set default command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ dotnet run --projectid "<projectid>" [--namespace "<custom-namespace>"] [--outpu
 - `--structuredmodel` - optional - generates `IRichTextContent` instead of `string` for rich-text elements. This enables utilizing [structured rich-text rendering](https://github.com/Kentico/delivery-sdk-net/wiki/Structured-Rich-text-rendering).
 - `--filenamesuffix` - optional - adds a suffix to generated filenames (e.g., News.cs becomes News.Generated.cs).
 
+These values can also be set to a default value in the appSettings.json file located in the `cloud-generators-net\src\CloudModelGenerator` directory. This will allow you to set a default values that will be used in place of command line arguments.
+
 
 ## Example output
 

--- a/src/CloudModelGenerator/CloudModelGenerator.csproj
+++ b/src/CloudModelGenerator/CloudModelGenerator.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="KenticoCloud.Delivery" Version="4.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.2" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/CloudModelGenerator/Program.cs
+++ b/src/CloudModelGenerator/Program.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Json;
 
 namespace CloudModelGenerator
 {
@@ -12,7 +9,6 @@ namespace CloudModelGenerator
         static IConfigurationRoot configuration { get; set; }
         static int Main(string[] args)
         {
-            var appSettingsPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
                 .AddJsonFile("appSettings.json");

--- a/src/CloudModelGenerator/appSettings.json
+++ b/src/CloudModelGenerator/appSettings.json
@@ -4,7 +4,7 @@
     "defaultFlags" : [
         {
             // Kentico Cloud Project ID
-            "projectId" : null, 
+            "projectId" : "", 
 
             // Namespace name of the generated classes
             "namespace" : null, 
@@ -16,10 +16,10 @@
             "filenameSuffix" : null, 
 
             // Indicates whether the CustomTypeProvider class should be generated
-            "withTypeProvder" : "false", 
+            "withTypeProvder" : null, 
             
              // Indicates whether the classes should be generated with types that represent structured data model
-            "structuredModel" : "false" 
+            "structuredModel" : null 
         }
     ]
 }

--- a/src/CloudModelGenerator/appSettings.json
+++ b/src/CloudModelGenerator/appSettings.json
@@ -1,0 +1,25 @@
+// This settings file will handle any default flags to pass to the application
+// Settings that are not set in this settings file will need to be passed via the command-line arguments
+{
+    "defaultFlags" : [
+        {
+            // Kentico Cloud Project ID
+            "projectId" : null, 
+
+            // Namespace name of the generated classes
+            "namespace" : null, 
+
+            // Output directory for the generated files
+            "outputdir" : null, 
+
+            // Optionally add suffix to the generated files
+            "filenameSuffix" : null, 
+
+            // Indicates whether the CustomTypeProvider class should be generated
+            "withTypeProvder" : "false", 
+            
+             // Indicates whether the classes should be generated with types that represent structured data model
+            "structuredModel" : "false" 
+        }
+    ]
+}


### PR DESCRIPTION
Added a appSettings.json file with the possible command-line arguments that a user can set and the application will look at these values before checking the CLI passed arguments. The application will always default to CLI passed arguments if no values are set.

