### PR TITLE
Generate empty partial classes

### DIFF
--- a/src/CloudModelGenerator/ClassCodeGenerator.cs
+++ b/src/CloudModelGenerator/ClassCodeGenerator.cs
@@ -13,11 +13,17 @@ namespace CloudModelGenerator
 
         public ClassDefinition ClassDefinition { get; }
 
+        public string ClassFilename { get; }
+
+        public bool OverwriteExisting { get; }
+
         public string Namespace { get; }
 
-        public ClassCodeGenerator(ClassDefinition classDefinition, string @namespace = DEFAULT_NAMESPACE)
+        public ClassCodeGenerator(ClassDefinition classDefinition, string classFilename, string @namespace = DEFAULT_NAMESPACE, bool overwriteExisting = true)
         {
             ClassDefinition = classDefinition ?? throw new ArgumentNullException(nameof(classDefinition));
+            ClassFilename = classFilename ?? ClassDefinition.ClassName;
+            OverwriteExisting = overwriteExisting;
             Namespace = @namespace ?? DEFAULT_NAMESPACE;
         }
 

--- a/src/CloudModelGenerator/ClassCodeGenerator.cs
+++ b/src/CloudModelGenerator/ClassCodeGenerator.cs
@@ -15,16 +15,19 @@ namespace CloudModelGenerator
 
         public string ClassFilename { get; }
 
-        public bool OverwriteExisting { get; }
+        public bool CustomPartial { get; }
 
         public string Namespace { get; }
 
-        public ClassCodeGenerator(ClassDefinition classDefinition, string classFilename, string @namespace = DEFAULT_NAMESPACE, bool overwriteExisting = true)
+        public bool OverwriteExisting { get; }
+
+        public ClassCodeGenerator(ClassDefinition classDefinition, string classFilename, string @namespace = DEFAULT_NAMESPACE, bool customPartial = false)
         {
             ClassDefinition = classDefinition ?? throw new ArgumentNullException(nameof(classDefinition));
             ClassFilename = classFilename ?? ClassDefinition.ClassName;
-            OverwriteExisting = overwriteExisting;
+            CustomPartial = customPartial;
             Namespace = @namespace ?? DEFAULT_NAMESPACE;
+            OverwriteExisting = !CustomPartial;
         }
 
         public string GenerateCode()
@@ -47,21 +50,6 @@ namespace CloudModelGenerator
                     )
             ).ToArray();
 
-            var classCodenameConstant = SyntaxFactory.FieldDeclaration(
-                            SyntaxFactory.VariableDeclaration(
-                                    SyntaxFactory.ParseTypeName("string"),
-                                    SyntaxFactory.SeparatedList(new[] {
-                                        SyntaxFactory.VariableDeclarator(
-                                            SyntaxFactory.Identifier("Codename"),
-                                            null,
-                                            SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression( SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(ClassDefinition.Codename)))
-                                        )
-                                    })
-                                )
-                            )
-                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
-                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.ConstKeyword));
-
             var propertyCodenameConstants = ClassDefinition.PropertyCodenameConstants.Select(element =>
                     SyntaxFactory.FieldDeclaration(
                             SyntaxFactory.VariableDeclaration(
@@ -81,9 +69,29 @@ namespace CloudModelGenerator
 
             var classDeclaration = SyntaxFactory.ClassDeclaration(ClassDefinition.ClassName)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
-                .AddModifiers(SyntaxFactory.Token(SyntaxKind.PartialKeyword))
-                .AddMembers(classCodenameConstant)
-                .AddMembers(propertyCodenameConstants)
+                .AddModifiers(SyntaxFactory.Token(SyntaxKind.PartialKeyword));
+
+            if (!CustomPartial)
+            {
+                var classCodenameConstant = SyntaxFactory.FieldDeclaration(
+                                SyntaxFactory.VariableDeclaration(
+                                        SyntaxFactory.ParseTypeName("string"),
+                                        SyntaxFactory.SeparatedList(new[] {
+                                            SyntaxFactory.VariableDeclarator(
+                                                SyntaxFactory.Identifier("Codename"),
+                                                null,
+                                                SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression( SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(ClassDefinition.Codename)))
+                                            )
+                                        })
+                                    )
+                                )
+                            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+                            .AddModifiers(SyntaxFactory.Token(SyntaxKind.ConstKeyword));
+
+                classDeclaration = classDeclaration.AddMembers(classCodenameConstant);
+            }
+
+            classDeclaration = classDeclaration.AddMembers(propertyCodenameConstants)
                 .AddMembers(properties);
 
             var description = SyntaxFactory.Comment(

--- a/src/CloudModelGenerator/CodeGenerator.cs
+++ b/src/CloudModelGenerator/CodeGenerator.cs
@@ -88,6 +88,10 @@ namespace CloudModelGenerator
             {
                 try
                 {
+                    if (_generatePartials)
+                    {
+                        codeGenerators.Add(GetCustomClassCodeGenerator(contentType));
+                    }
                     codeGenerators.Add(GetClassCodeGenerator(contentType, structuredModel));
                 }
                 catch (InvalidIdentifierException)
@@ -139,7 +143,8 @@ namespace CloudModelGenerator
                 Console.WriteLine($"Warning: Can't add 'System' property. It's in collision with existing element in Content Type '{classDefinition.ClassName}'.");
             }
 
-            string classFilename = $"{classDefinition.ClassName}{_fileNameSuffix}";
+            string suffix = string.IsNullOrEmpty(_fileNameSuffix) ? "" : $".{_fileNameSuffix}";
+            string classFilename = $"{classDefinition.ClassName}{suffix}";
             return new ClassCodeGenerator(classDefinition, classFilename, _namespace);
         }
 

--- a/src/CloudModelGenerator/CodeGenerator.cs
+++ b/src/CloudModelGenerator/CodeGenerator.cs
@@ -45,7 +45,7 @@ namespace CloudModelGenerator
 
             foreach (var codeGenerator in classCodeGenerators)
             {
-                SaveToFile(codeGenerator.GenerateCode(), codeGenerator.ClassFilename);
+                SaveToFile(codeGenerator.GenerateCode(), codeGenerator.ClassFilename, codeGenerator.OverwriteExisting);
             }
 
             Console.WriteLine($"{classCodeGenerators.Count()} content type models were successfully created.");
@@ -152,7 +152,7 @@ namespace CloudModelGenerator
         {
             var classDefinition = new ClassDefinition(contentType.System.Codename);
             string classFilename = $"{classDefinition.ClassName}";
-            return new ClassCodeGenerator(classDefinition, classFilename, _namespace, false);
+            return new ClassCodeGenerator(classDefinition, classFilename, _namespace, true);
         }
     }
 }

--- a/src/CloudModelGenerator/CodeGenerator.cs
+++ b/src/CloudModelGenerator/CodeGenerator.cs
@@ -13,14 +13,21 @@ namespace CloudModelGenerator
         private readonly string _namespace;
         private readonly string _outputDir;
         private readonly string _fileNameSuffix;
+        private readonly bool _generatePartials;
 
         public DeliveryClient Client { get; }
 
-        public CodeGenerator(string projectId, string outputDir, string @namespace = null, string fileNameSuffix = null)
+        public CodeGenerator(string projectId, string outputDir, string @namespace = null, string fileNameSuffix = null, bool generatePartials = false)
         {
             _projectId = projectId;
             _namespace = @namespace;
             _fileNameSuffix = fileNameSuffix;
+            _generatePartials = generatePartials;
+
+            if (_generatePartials && string.IsNullOrEmpty(_fileNameSuffix))
+            {
+                _fileNameSuffix = "Generated";
+            }
 
             // Resolve relative path to full path
             _outputDir = Path.GetFullPath(outputDir).TrimEnd('\\') + "\\";
@@ -38,7 +45,7 @@ namespace CloudModelGenerator
 
             foreach (var codeGenerator in classCodeGenerators)
             {
-                SaveToFile(codeGenerator.GenerateCode(), codeGenerator.ClassDefinition.ClassName);
+                SaveToFile(codeGenerator.GenerateCode(), codeGenerator.ClassFilename);
             }
 
             Console.WriteLine($"{classCodeGenerators.Count()} content type models were successfully created.");
@@ -62,11 +69,14 @@ namespace CloudModelGenerator
             Console.WriteLine($"{TypeProviderCodeGenerator.CLASS_NAME} class was successfully created.");
         }
 
-        private void SaveToFile(string content, string fileName)
+        private void SaveToFile(string content, string fileName, bool overwriteExisting = true)
         {
-            string suffix = string.IsNullOrWhiteSpace(_fileNameSuffix) ? ".cs" : $".{_fileNameSuffix}.cs";
-            string outputPath = _outputDir + $"{fileName}{suffix}";
-            File.WriteAllText(outputPath, content);
+            string outputPath = _outputDir + $"{fileName}.cs";
+            bool fileExists = File.Exists(outputPath);
+            if (!fileExists || overwriteExisting)
+            {
+                File.WriteAllText(outputPath, content);
+            }
         }
 
         private IEnumerable<ClassCodeGenerator> GetClassCodeGenerators(bool structuredModel = false)
@@ -129,7 +139,15 @@ namespace CloudModelGenerator
                 Console.WriteLine($"Warning: Can't add 'System' property. It's in collision with existing element in Content Type '{classDefinition.ClassName}'.");
             }
 
-            return new ClassCodeGenerator(classDefinition, _namespace);
+            string classFilename = $"{classDefinition.ClassName}{_fileNameSuffix}";
+            return new ClassCodeGenerator(classDefinition, classFilename, _namespace);
+        }
+
+        private ClassCodeGenerator GetCustomClassCodeGenerator(ContentType contentType)
+        {
+            var classDefinition = new ClassDefinition(contentType.System.Codename);
+            string classFilename = $"{classDefinition.ClassName}";
+            return new ClassCodeGenerator(classDefinition, classFilename, _namespace, false);
         }
     }
 }

--- a/src/CloudModelGenerator/Program.cs
+++ b/src/CloudModelGenerator/Program.cs
@@ -26,6 +26,7 @@ namespace CloudModelGenerator
             var namespaceOption = app.Option("-n|--namespace", "Namespace name of the generated classes.", CommandOptionType.SingleValue);
             var outputDirOption = app.Option("-o|--outputdir", "Output directory for the generated files.", CommandOptionType.SingleValue);
             var fileNameSuffixOption = app.Option("-sf|--filenamesuffix", "Optionally add a suffix to generated filenames (e.g., News.cs becomes News.Generated.cs).", CommandOptionType.SingleValue);
+            var generatePartials = app.Option("-gp|--generatepartials", "Generate partial classes for customisation (if this option is set filename suffix will default to Generated).", CommandOptionType.NoValue);
             var includeTypeProvider = app.Option("-t|--withtypeprovider", "Indicates whether the CustomTypeProvider class should be generated.", CommandOptionType.NoValue);
             var structuredModel = app.Option("-s|--structuredmodel", "Indicates whether the classes should be generated with types that represent structured data model.", CommandOptionType.NoValue);
             
@@ -35,6 +36,7 @@ namespace CloudModelGenerator
                 var passedSetProjectId = projectIdOption.Value() ?? Configuration["projectId"];
                 var passedSetNamespace = namespaceOption.Value() ?? Configuration["namespace"];
                 var passedSetOutputDir = outputDirOption.Value() ?? Configuration["outputdir"];
+                var passedGeneratePartials = generatePartials.HasValue() ? bool.Parse(generatePartials.Value()) : Configuration.GetValue("generatePartials", false);
                 var passedSetFileNameSuffix = fileNameSuffixOption.Value() ?? Configuration["filenameSuffix"];
                 var passedSetIncludeTypeProvider = includeTypeProvider.HasValue() ? bool.Parse(includeTypeProvider.Value()) : Configuration.GetValue("withTypeProvider", true);
                 var passedSetStructuredModel = structuredModel.HasValue() ? bool.Parse(structuredModel.Value()) : Configuration.GetValue("structuredModel", false);
@@ -51,7 +53,7 @@ namespace CloudModelGenerator
                 const string CURRENT_DIRECTORY = ".";
                 string outputDir = passedSetOutputDir ?? CURRENT_DIRECTORY;
 
-                var codeGenerator = new CodeGenerator(passedSetProjectId, outputDir, passedSetNamespace, passedSetFileNameSuffix);
+                var codeGenerator = new CodeGenerator(passedSetProjectId, outputDir, passedSetNamespace, passedSetFileNameSuffix, passedGeneratePartials);
 
                 codeGenerator.GenerateContentTypeModels(passedSetStructuredModel);
 

--- a/src/CloudModelGenerator/appSettings.json
+++ b/src/CloudModelGenerator/appSettings.json
@@ -13,6 +13,9 @@
   // Optionally add suffix to the generated files
   "filenameSuffix": null,
 
+  // Optionally add suffix to the generated files
+  "generatePartials": null,
+
   // Indicates whether the CustomTypeProvider class should be generated
   "withTypeProvder": null,
 

--- a/test/CloudModelGenerator.Tests/ClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/ClassCodeGeneratorTests.cs
@@ -16,7 +16,7 @@ namespace CloudModelGenerator.Tests
         [Fact]
         public void Constructor_ThrowsAnExceptionForNullArgument()
         {
-            Assert.Throws<ArgumentNullException>(() => new ClassCodeGenerator(null));
+            Assert.Throws<ArgumentNullException>(() => new ClassCodeGenerator(null, null));
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace CloudModelGenerator.Tests
 
             classDefinition.AddSystemProperty();
 
-            var classCodeGenerator = new ClassCodeGenerator(classDefinition);
+            var classCodeGenerator = new ClassCodeGenerator(classDefinition, classDefinition.ClassName);
 
             string compiledCode = classCodeGenerator.GenerateCode();
 
@@ -73,7 +73,7 @@ namespace CloudModelGenerator.Tests
             definition.AddProperty(Property.FromContentType("modular_content", "modular_content"));
             definition.AddProperty(Property.FromContentType("taxonomy", "taxonomy"));
 
-            var classCodeGenerator = new ClassCodeGenerator(definition);
+            var classCodeGenerator = new ClassCodeGenerator(definition, definition.ClassName);
             string compiledCode = classCodeGenerator.GenerateCode();
 
             CSharpCompilation compilation = CSharpCompilation.Create(

--- a/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
@@ -63,7 +63,6 @@ namespace CloudModelGenerator.Tests
             codeGenerator.Client.HttpClient = httpClient;
 
             codeGenerator.GenerateContentTypeModels();
-            codeGenerator.GenerateTypeProvider();
 
             Assert.True(Directory.GetFiles(Path.GetFullPath(TEMP_DIR)).Length > 10);
 

--- a/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
@@ -93,11 +93,11 @@ namespace CloudModelGenerator.Tests
 
             codeGenerator.GenerateContentTypeModels();
 
-            var allFilesCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), ".cs").Length;
-            var generatedCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), $".{transformFilename}.cs").Length;
+            var allFilesCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), "*.cs").Length;
+            var generatedCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), $"*.{transformFilename}.cs").Length;
             Assert.Equal(allFilesCount, generatedCount * 2);
 
-            foreach (var filepath in Directory.EnumerateFiles(Path.GetFullPath(TEMP_DIR), $".{transformFilename}.cs"))
+            foreach (var filepath in Directory.EnumerateFiles(Path.GetFullPath(TEMP_DIR), $"*.{transformFilename}.cs"))
             {
                 var customFileExists = File.Exists(filepath.Replace($".{transformFilename}", ""));
                 Assert.True(customFileExists);

--- a/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
@@ -75,5 +75,36 @@ namespace CloudModelGenerator.Tests
             // Cleanup
             Directory.Delete(TEMP_DIR, true);
         }
+
+        [Fact]
+        public void IntegrationTestWithGeneratePartials()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://deliver.kenticocloud.com/*")
+                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures\\types.json")));
+            var httpClient = mockHttp.ToHttpClient();
+
+            const string PROJECT_ID = "975bf280-fd91-488c-994c-2f04416e5ee3";
+            const string @namespace = "CustomNamespace";
+            const string transformFilename = "Generated";
+
+            var codeGenerator = new CodeGenerator(PROJECT_ID, TEMP_DIR, @namespace, transformFilename, true);
+            codeGenerator.Client.HttpClient = httpClient;
+
+            codeGenerator.GenerateContentTypeModels();
+
+            var allFilesCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), ".cs").Length;
+            var generatedCount = Directory.GetFiles(Path.GetFullPath(TEMP_DIR), $".{transformFilename}.cs").Length;
+            Assert.Equal(allFilesCount, generatedCount * 2);
+
+            foreach (var filepath in Directory.EnumerateFiles(Path.GetFullPath(TEMP_DIR), $".{transformFilename}.cs"))
+            {
+                var customFileExists = File.Exists(filepath.Replace($".{transformFilename}", ""));
+                Assert.True(customFileExists);
+            }
+
+            // Cleanup
+            Directory.Delete(TEMP_DIR, true);
+        }
     }
 }


### PR DESCRIPTION
#31 The utility can generate empty partial classes for customization by developer with -gf|generatepartials. The classes would be generated only if they don't exist before.