### PR TITLE
Codename constant bugfixing

### DIFF
--- a/src/CloudModelGenerator/ClassCodeGenerator.cs
+++ b/src/CloudModelGenerator/ClassCodeGenerator.cs
@@ -88,7 +88,7 @@ namespace CloudModelGenerator
                                     SyntaxFactory.ParseTypeName("string"),
                                     SyntaxFactory.SeparatedList(new[] {
                                         SyntaxFactory.VariableDeclarator(
-                                            SyntaxFactory.Identifier($"{TextHelpers.GetValidPascalCaseIdentifierName(element.Name)}Codename"),
+                                            SyntaxFactory.Identifier($"{TextHelpers.GetValidPascalCaseIdentifierName(element.Codename)}Codename"),
                                             null,
                                             SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression( SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(element.Codename)))
                                         )


### PR DESCRIPTION
When a content type uses a snippet and the snippet has an element with the same name of another element in the parent type, Deliver generates a number suffix to the snippet name to the system.codename field. With the fix, the generator will generate the same identifier for both the constant and its corresponding property. Relates to #55.