### PR TITLE
Fixes #54

### DIFF
--- a/src/CloudModelGenerator/Program.cs
+++ b/src/CloudModelGenerator/Program.cs
@@ -16,35 +16,8 @@ namespace CloudModelGenerator
 
         static int Main(string[] args)
         {
-            var correctedArgs = new List<string>();
-
-            foreach (var arg in args)
-            {
-                // Argument value incorrectly parsed by the runtime (due to the use of a "backslash and double quotes" sequence).
-                var valueWithQuotes = Regex.Match(arg, @"(.+)("")");
-
-                // Argument names and values trailing after the valueWithQuotes sequence.
-                var pairs = Regex.Matches(arg, @"(-\w+)\s([^\s]+)");
-
-                if (valueWithQuotes.Success || pairs.Any(p => p.Success))
-                {
-                    if (valueWithQuotes.Success)
-                    {
-                        correctedArgs.Add(valueWithQuotes.Groups[1].Value);
-                    }
-
-                    foreach (var success in pairs.Where(m => m.Success))
-                    {
-                        correctedArgs.AddRange(new[] { success.Groups[1].Value, success.Groups[2].Value });
-                    } 
-                }
-                else
-                {
-                    correctedArgs.Add(arg);
-                }
-            }
-
-            var syntax = Parse(correctedArgs.ToArray());
+            var correctedArgs = CorrectArguments(args);
+            var syntax = Parse(correctedArgs);
             var unexpectedArgs = new List<string>(syntax.RemainingArguments);
 
             if (unexpectedArgs.Count > 0)
@@ -60,6 +33,37 @@ namespace CloudModelGenerator
             }
 
             return Execute(syntax);
+        }
+
+        internal static string[] CorrectArguments(string[] args)
+        {
+            var correctedArgs = new List<string>();
+            foreach (var arg in args)
+            {
+                // Argument value incorrectly parsed by the runtime (due to the use of a "backslash and double quotes" sequence).
+                var valueWithQuotes = Regex.Match(arg, @"(.+)("")");
+
+                // Argument names and values trailing after the valueWithQuotes sequence.
+                var pairs = Regex.Matches(arg, @"(-{1,2}\w+)\s([^\s]+)");
+
+                if (valueWithQuotes.Success || pairs.Any(p => p.Success))
+                {
+                    if (valueWithQuotes.Success)
+                    {
+                        correctedArgs.Add(valueWithQuotes.Groups[1].Value);
+                    }
+
+                    foreach (var success in pairs.Where(m => m.Success))
+                    {
+                        correctedArgs.AddRange(new[] { success.Groups[1].Value, success.Groups[2].Value });
+                    }
+                }
+                else
+                {
+                    correctedArgs.Add(arg);
+                }
+            }
+            return correctedArgs.ToArray();
         }
 
         internal static ArgumentSyntax Parse(string[] args)

--- a/test/CloudModelGenerator.Tests/ProgramTests.cs
+++ b/test/CloudModelGenerator.Tests/ProgramTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using Xunit;
 
@@ -24,6 +25,48 @@ namespace CloudModelGenerator.Tests
 
             var options = Program.CreateCodeGeneratorOptions(preparedSyntax);
             Assert.Equal("./", options.OutputDir);
+        }
+
+        public static IEnumerable<object[]> GetInputForCorrectArguments()
+        {
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" --namespace Some.NameSpace" },
+                new string[] { "--outputdir", @"C:\KC\demo\", "--namespace", "Some.NameSpace" },
+            };
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" -n Some.NameSpace" },
+                new string[] { "--outputdir", @"C:\KC\demo\", "-n", "Some.NameSpace" },
+            };
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" --generatepartials"  },
+                new string[] { "--outputdir", @"C:\KC\demo\", "--generatepartials" }
+            };
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" --namespace Some.NameSpace -g" },
+                new string[] { "--outputdir", @"C:\KC\demo\", "--namespace", "Some.NameSpace", "-g" },
+            };
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" --namespace Some.NameSpace --generatepartials" },
+                new string[] { "--outputdir", @"C:\KC\demo\", "--namespace", "Some.NameSpace", "--generatepartials" },
+            };
+            yield return new string[][]
+            {
+                new string[] { "--outputdir", @"C:\KC\demo\"" --namespace Some.NameSpace --generatepartials -s --projectId 975bf280-fd91-488c-994c-2f04416e5ee3" },
+                new string[] { "--outputdir", @"C:\KC\demo\", "--namespace", "Some.NameSpace", "--generatepartials", "-s", "--projectId", "975bf280-fd91-488c-994c-2f04416e5ee3" },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInputForCorrectArguments))]
+        public void CorrectArguments_CorrectionPerformed(string[] inputArgs, string[] expectedArgs)
+        {
+            var correctedArgs = Program.CorrectArguments(inputArgs);
+            Assert.Equal(expectedArgs, correctedArgs);
         }
     }
 }


### PR DESCRIPTION
When using the `-o "C:\Some path\"` command line argument (with the "backslash and double quotes" sequence in the end, the runtime does an incorrect initial parse of the argument.

Fixes #54 