### PR TITLE
Base Class and Type Provider tests refactoring

### DIFF
--- a/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
@@ -15,9 +15,9 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            string actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
-            string executingPath = AppContext.BaseDirectory;
-            string expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
+            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
+            var executingPath = AppContext.BaseDirectory;
+            var expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
 
             Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
@@ -25,34 +25,31 @@ namespace CloudModelGenerator.Tests
         [Fact]
         public void GenerateBaseClassCodeWithCustomNamespace()
         {
-            string customNamespace = "CustomNamespace";
+            var customNamespace = "CustomNamespace";
             var codeGenerator = new BaseClassCodeGenerator(BASE_CLASS_NAME, customNamespace);
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            string actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
-            string executingPath = AppContext.BaseDirectory;
+            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
+            var executingPath = AppContext.BaseDirectory;
             var expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
             
-            // Replace default namespace in expected result
             expected_BaseClassCode = expected_BaseClassCode.Replace(ClassCodeGenerator.DEFAULT_NAMESPACE, customNamespace);
 
-            // Test base class
             Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
 
         [Fact]
         public void GenerateExtenderClassCode()
         {
-            string codeGenerator = new BaseClassCodeGenerator(BASE_CLASS_NAME);
+            var codeGenerator = new BaseClassCodeGenerator(BASE_CLASS_NAME);
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            string actualCompiled_ExtenderClass = codeGenerator.GenereateExtenderCode();
-            string executingPath = AppContext.BaseDirectory;
-            string expected_ExtenderCode = File.ReadAllText(executingPath + "/Assets/BaseClassExtender_CompiledCode.txt");
+            var actualCompiled_ExtenderClass = codeGenerator.GenereateExtenderCode();
+            var executingPath = AppContext.BaseDirectory;
+            var expected_ExtenderCode = File.ReadAllText(executingPath + "/Assets/BaseClassExtender_CompiledCode.txt");
 
-            // Test extender class
             Assert.Equal(expected_ExtenderCode, actualCompiled_ExtenderClass, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }
     }

--- a/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
@@ -15,9 +15,10 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
             var executingPath = AppContext.BaseDirectory;
             var expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
+
+            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
 
             Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
@@ -30,11 +31,11 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
             var executingPath = AppContext.BaseDirectory;
             var expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
-            
             expected_BaseClassCode = expected_BaseClassCode.Replace(ClassCodeGenerator.DEFAULT_NAMESPACE, customNamespace);
+
+            var actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();            
 
             Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
@@ -46,9 +47,10 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
-            var actualCompiled_ExtenderClass = codeGenerator.GenereateExtenderCode();
             var executingPath = AppContext.BaseDirectory;
             var expected_ExtenderCode = File.ReadAllText(executingPath + "/Assets/BaseClassExtender_CompiledCode.txt");
+
+            var actualCompiled_ExtenderClass = codeGenerator.GenereateExtenderCode();
 
             Assert.Equal(expected_ExtenderCode, actualCompiled_ExtenderClass, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }

--- a/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
@@ -19,8 +19,7 @@ namespace CloudModelGenerator.Tests
             string executingPath = AppContext.BaseDirectory;
             string expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
 
-            // Test base class
-            Assert.Equal(actualCompiled_BaseClass, expected_BaseClassCode, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
+            Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
 
         [Fact]
@@ -33,19 +32,19 @@ namespace CloudModelGenerator.Tests
 
             string actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
             string executingPath = AppContext.BaseDirectory;
-            string expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
+            var expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
             
             // Replace default namespace in expected result
             expected_BaseClassCode = expected_BaseClassCode.Replace(ClassCodeGenerator.DEFAULT_NAMESPACE, customNamespace);
 
             // Test base class
-            Assert.Equal(actualCompiled_BaseClass, expected_BaseClassCode, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
+            Assert.Equal(expected_BaseClassCode, actualCompiled_BaseClass, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
 
         [Fact]
         public void GenerateExtenderClassCode()
         {
-            var codeGenerator = new BaseClassCodeGenerator(BASE_CLASS_NAME);
+            string codeGenerator = new BaseClassCodeGenerator(BASE_CLASS_NAME);
             codeGenerator.AddClassNameToExtend("Article");
             codeGenerator.AddClassNameToExtend("Office");
 
@@ -54,7 +53,7 @@ namespace CloudModelGenerator.Tests
             string expected_ExtenderCode = File.ReadAllText(executingPath + "/Assets/BaseClassExtender_CompiledCode.txt");
 
             // Test extender class
-            Assert.Equal(actualCompiled_ExtenderClass, expected_ExtenderCode, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+            Assert.Equal(expected_ExtenderCode, actualCompiled_ExtenderClass, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }
     }
 }

--- a/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System;
 using System.IO;
-using System.Text.RegularExpressions;
 
 namespace CloudModelGenerator.Tests
 {

--- a/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/BaseClassCodeGeneratorTests.cs
@@ -20,10 +20,6 @@ namespace CloudModelGenerator.Tests
             string executingPath = AppContext.BaseDirectory;
             string expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
 
-            // Line endings can vary due to git, so strip them out
-            expected_BaseClassCode = Regex.Replace(expected_BaseClassCode, @"\s+", "");
-            actualCompiled_BaseClass = Regex.Replace(actualCompiled_BaseClass, @"\s+", "");
-
             // Test base class
             Assert.Equal(actualCompiled_BaseClass, expected_BaseClassCode, ignoreLineEndingDifferences:true, ignoreWhiteSpaceDifferences: true);
         }
@@ -39,10 +35,6 @@ namespace CloudModelGenerator.Tests
             string actualCompiled_BaseClass = codeGenerator.GenerateBaseClassCode();
             string executingPath = AppContext.BaseDirectory;
             string expected_BaseClassCode = File.ReadAllText(executingPath + "/Assets/BaseClass_CompiledCode.txt");
-
-            // Line endings can vary due to git, so strip them out
-            actualCompiled_BaseClass = Regex.Replace(actualCompiled_BaseClass, @"\s+", "");
-            expected_BaseClassCode = Regex.Replace(expected_BaseClassCode, @"\s+", "");
             
             // Replace default namespace in expected result
             expected_BaseClassCode = expected_BaseClassCode.Replace(ClassCodeGenerator.DEFAULT_NAMESPACE, customNamespace);
@@ -61,10 +53,6 @@ namespace CloudModelGenerator.Tests
             string actualCompiled_ExtenderClass = codeGenerator.GenereateExtenderCode();
             string executingPath = AppContext.BaseDirectory;
             string expected_ExtenderCode = File.ReadAllText(executingPath + "/Assets/BaseClassExtender_CompiledCode.txt");
-
-            // Line endings can vary due to git, so strip them out
-            actualCompiled_ExtenderClass = Regex.Replace(actualCompiled_ExtenderClass, @"\s+", "");
-            expected_ExtenderCode = Regex.Replace(expected_ExtenderCode, @"\s+", "");
 
             // Test extender class
             Assert.Equal(actualCompiled_ExtenderClass, expected_ExtenderCode, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);

--- a/test/CloudModelGenerator.Tests/ClassCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/ClassCodeGeneratorTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
-using KenticoCloud.Delivery;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
@@ -53,11 +51,7 @@ namespace CloudModelGenerator.Tests
             string executingPath = AppContext.BaseDirectory;
             string expectedCode = File.ReadAllText(executingPath + "/Assets/CompleteContentType_CompiledCode.txt");
 
-            // Ignore white space
-            expectedCode = Regex.Replace(expectedCode, @"\s+", "");
-            compiledCode = Regex.Replace(compiledCode, @"\s+", "");
-
-            Assert.Equal(expectedCode, compiledCode);
+            Assert.Equal(expectedCode, compiledCode, ignoreWhiteSpaceDifferences: true, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -81,11 +75,7 @@ namespace CloudModelGenerator.Tests
             var executingPath = AppContext.BaseDirectory;
             var expectedCode = File.ReadAllText(executingPath + "/Assets/CompleteContentType_CompiledCode_CMAPI.txt");
 
-            // Ignore white space
-            expectedCode = Regex.Replace(expectedCode, @"\s+", "");
-            compiledCode = Regex.Replace(compiledCode, @"\s+", "");
-
-            Assert.Equal(expectedCode, compiledCode);
+            Assert.Equal(expectedCode, compiledCode, ignoreWhiteSpaceDifferences: true, ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
@@ -28,7 +28,7 @@ namespace CloudModelGenerator.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://deliver.kenticocloud.com/*")
-                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures\\types.json")));
+                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures/types.json")));
             var httpClient = mockHttp.ToHttpClient();
 
             var mockOptions = new Mock<IOptions<CodeGeneratorOptions>>();
@@ -64,7 +64,7 @@ namespace CloudModelGenerator.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://deliver.kenticocloud.com/*")
-                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures\\types.json")));
+                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures/types.json")));
             var httpClient = mockHttp.ToHttpClient();
 
             const string transformFilename = "Generated";
@@ -102,7 +102,7 @@ namespace CloudModelGenerator.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://deliver.kenticocloud.com/*")
-                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures\\types.json")));
+                    .Respond("application/json", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures/types.json")));
             var httpClient = mockHttp.ToHttpClient();
 
             const string transformFilename = "Generated";

--- a/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
@@ -19,10 +19,10 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddContentType("article", "Article");
             codeGenerator.AddContentType("office", "Office");
 
-            string compiledCode = codeGenerator.GenerateCode();
+            var compiledCode = codeGenerator.GenerateCode();
 
-            string executingPath = AppContext.BaseDirectory;
-            string expectedCode = File.ReadAllText(executingPath + "/Assets/CustomTypeProvider_CompiledCode.txt");
+            var executingPath = AppContext.BaseDirectory;
+            var expectedCode = File.ReadAllText(executingPath + "/Assets/CustomTypeProvider_CompiledCode.txt");
 
             Assert.Equal(expectedCode, compiledCode, ignoreWhiteSpaceDifferences: true, ignoreLineEndingDifferences: true);
         }
@@ -34,10 +34,10 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddContentType("article", "Article");
             codeGenerator.AddContentType("office", "Office");
 
-            string compiledCode = codeGenerator.GenerateCode();
+            var compiledCode = codeGenerator.GenerateCode();
 
             // Dummy implementation of Article and Office class to make compilation work
-            string dummyClasses = "public class Article {} public class Office {}";
+            var dummyClasses = "public class Article {} public class Office {}";
 
             CSharpCompilation compilation = CSharpCompilation.Create(
                 assemblyName: Path.GetRandomFileName(),
@@ -56,7 +56,7 @@ namespace CloudModelGenerator.Tests
             using (var ms = new MemoryStream())
             {
                 EmitResult result = compilation.Emit(ms);
-                string compilationErrors = "Compilation errors:\n";
+                var compilationErrors = $"Compilation errors:{Environment.NewLine}";
 
                 if (!result.Success)
                 {
@@ -66,7 +66,7 @@ namespace CloudModelGenerator.Tests
 
                     foreach (Diagnostic diagnostic in failures)
                     {
-                        compilationErrors += String.Format("{0}: {1}\n", diagnostic.Id, diagnostic.GetMessage());
+                        compilationErrors += String.Format($"{diagnostic.Id}: {diagnostic.GetMessage()}{Environment.NewLine}");
                     }
                 }
 

--- a/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace CloudModelGenerator.Tests
 {
@@ -25,13 +24,9 @@ namespace CloudModelGenerator.Tests
             string executingPath = AppContext.BaseDirectory;
             string expectedCode = File.ReadAllText(executingPath + "/Assets/CustomTypeProvider_CompiledCode.txt");
 
-            // Ignore white space
-            expectedCode = Regex.Replace(expectedCode, @"\s+", "");
-            compiledCode = Regex.Replace(compiledCode, @"\s+", "");
-
-            Assert.Equal(expectedCode, compiledCode);
+            Assert.Equal(expectedCode, compiledCode, ignoreWhiteSpaceDifferences: true, ignoreLineEndingDifferences: true);
         }
-        
+
         [Fact]
         public void IntegrationTest_GeneratedCodeCompilesWithoutErrors()
         {

--- a/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
@@ -19,11 +19,11 @@ namespace CloudModelGenerator.Tests
             codeGenerator.AddContentType("article", "Article");
             codeGenerator.AddContentType("office", "Office");
 
-            var compiledCode = codeGenerator.GenerateCode();
-
             var executingPath = AppContext.BaseDirectory;
             var expectedCode = File.ReadAllText(executingPath + "/Assets/CustomTypeProvider_CompiledCode.txt");
 
+            var compiledCode = codeGenerator.GenerateCode();
+          
             Assert.Equal(expectedCode, compiledCode, ignoreWhiteSpaceDifferences: true, ignoreLineEndingDifferences: true);
         }
 


### PR DESCRIPTION
I have gone through the tests in files:
* BaseClassCodeGeneratorTests.cs
* TypeProviderCodeGeneratorTests.cs

Most important change is that I have removed regular expressions for striping whitespaces (new lines character) and set up equals method to ignore whitespaces and new line characters when checking equality:
* https://github.com/Kentico/cloud-generators-net/commit/350b583efb4f4339ba1049460ba7dcaca43fd5a4

Then I have switched the order of parameters 
* https://github.com/Kentico/cloud-generators-net/commit/20516d9896246e105cb553df4b1be0a237a5f879

Other commits are just some code polishing:
* As you could see in the commits message. I have performed some refactoring

We have been discussing, that git configuration could influence how does the `Equals` work for xunit (https://github.com/Kentico/cloud-generators-net/pull/70). 
* I have tried to run tests on Linux Ubuntu and also on windows with various configurations of git  `core.autocrlf` config key and I was not able to reproduce the issue, neither on the appveyor CI:
  * Dave's: https://ci.appveyor.com/project/kentico/cloud-generators-net/build/1.5.163
  * My output: https://ci.appveyor.com/project/kentico/cloud-generators-net/build/1.5.166

I have decided to not use the workaround with the regular expression. The `Equals` method should ignore line endings - if it doesn't, it is a bug of xunit and it needs to be submitted and resolved. 






