### PR TITLE
KA-395 Add generating of GetCodename method to TypeProviderCodeGenera…

### DIFF
--- a/src/CloudModelGenerator/CloudModelGenerator.csproj
+++ b/src/CloudModelGenerator/CloudModelGenerator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ILLink.Tasks" Version="0.1.4-preview-981901" />
-    <PackageReference Include="KenticoCloud.Delivery" Version="4.12.0" />
+    <PackageReference Include="KenticoCloud.Delivery" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />

--- a/src/CloudModelGenerator/TypeProviderCodeGenerator.cs
+++ b/src/CloudModelGenerator/TypeProviderCodeGenerator.cs
@@ -51,31 +51,38 @@ namespace CloudModelGenerator
                 return null;
             }
 
-            string switchCases = _contentTypes
-                .Select((c) => $"case \"{c.Key}\": return typeof({c.Value});")
-                .Aggregate((p, n) => p + Environment.NewLine + n);
-            
+            var codenameDictionaryValues = _contentTypes
+                .Select(entry => $"\t\t\t{{typeof({entry.Value}), \"{entry.Key}\"}}")
+                .Aggregate((previous, next) => previous + "," + Environment.NewLine + next);
+
             var tree = CSharpSyntaxTree.ParseText(
 $@"using System;
+using System.Collections.Generic;
+using System.Linq;
 using KenticoCloud.Delivery;
 
 namespace {_namespace}
 {{
     public class {CLASS_NAME} : ICodeFirstTypeProvider
     {{
+        private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+        {{
+{codenameDictionaryValues}
+        }};
+
         public Type GetType(string contentType)
         {{
-            switch (contentType)
-            {{
-                {switchCases}
-                default:
-                    return null;
-            }}
+            return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
+        }}
+
+        public string GetCodename(Type contentType)
+        {{
+            return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
         }}
     }}
 }}");
 
-            var cu = (CompilationUnitSyntax)tree.GetRoot().NormalizeWhitespace();
+            var cu = (CompilationUnitSyntax)tree.GetRoot();
 
             AdhocWorkspace cw = new AdhocWorkspace();
             return Formatter.Format(cu, cw).ToFullString();

--- a/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
+++ b/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
@@ -5,22 +5,22 @@ using KenticoCloud.Delivery;
 
 namespace KenticoCloudModels
 {
-    public class CustomTypeProvider : ICodeFirstTypeProvider
-    {
-        private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+	public class CustomTypeProvider : ICodeFirstTypeProvider
 	{
-		{typeof(Article), "article"},
-		{typeof(Office), "office"}
-	};
+		private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+		{
+			{typeof(Article), "article"},
+			{typeof(Office), "office"}
+		};
 
-	public Type GetType(string contentType)
-        {
-            return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
-        }
+		public Type GetType(string contentType)
+		{
+			return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
+		}
 
-        public string GetCodename(Type contentType)
-        {
-            return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
-        }
-    }
+		public string GetCodename(Type contentType)
+		{
+			return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
+		}
+	}
 }

--- a/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
+++ b/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
@@ -1,21 +1,26 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using KenticoCloud.Delivery;
 
 namespace KenticoCloudModels
 {
     public class CustomTypeProvider : ICodeFirstTypeProvider
     {
-        public Type GetType(string contentType)
+        private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
+	{
+		{typeof(Article), "article"},
+		{typeof(Office), "office"}
+	};
+
+	public Type GetType(string contentType)
         {
-            switch (contentType)
-            {
-                case "article":
-                    return typeof(Article);
-                case "office":
-                    return typeof(Office);
-                default:
-                    return null;
-            }
+            return _codenames.Keys.FirstOrDefault(type => GetCodename(type).Equals(contentType));
+        }
+
+        public string GetCodename(Type contentType)
+        {
+            return _codenames.TryGetValue(contentType, out var codename) ? codename : null;
         }
     }
 }

--- a/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
@@ -46,6 +46,7 @@ namespace CloudModelGenerator.Tests
                     CSharpSyntaxTree.ParseText(dummyClasses)
                 },
                 references: new[] {
+                    MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("netstandard")).Location),
                     MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("mscorlib")).Location),
                     MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("System.Runtime")).Location),
                     MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("System.Linq")).Location),

--- a/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/TypeProviderCodeGeneratorTests.cs
@@ -48,6 +48,7 @@ namespace CloudModelGenerator.Tests
                 references: new[] {
                     MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("mscorlib")).Location),
                     MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("System.Runtime")).Location),
+                    MetadataReference.CreateFromFile(Assembly.Load(new AssemblyName("System.Linq")).Location),
                     MetadataReference.CreateFromFile(typeof(Object).GetTypeInfo().Assembly.Location),
                     MetadataReference.CreateFromFile(typeof(KenticoCloud.Delivery.DeliveryClient).GetTypeInfo().Assembly.Location)
                 },


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`61`

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Check if the generated `CustomTypeProvider.cs` file contains a valid C# code and it does what it should.