### PR TITLE
Fix hardcoded path separators

### DIFF
--- a/src/CloudModelGenerator/CodeGenerator.cs
+++ b/src/CloudModelGenerator/CodeGenerator.cs
@@ -24,7 +24,7 @@ namespace CloudModelGenerator
             }
 
             // Resolve relative path to full path
-            _options.OutputDir = Path.GetFullPath(_options.OutputDir).TrimEnd('\\') + "\\";
+            _options.OutputDir = Path.GetFullPath(_options.OutputDir);
 
             // Initialize DeliveryClient
             Client = new DeliveryClient(_options.ProjectId);
@@ -83,7 +83,7 @@ namespace CloudModelGenerator
 
         private void SaveToFile(string content, string fileName, bool overwriteExisting = true)
         {
-            string outputPath = _options.OutputDir + $"{fileName}.cs";
+            string outputPath = Path.Combine(_options.OutputDir, $"{fileName}.cs");
             bool fileExists = File.Exists(outputPath);
             if (!fileExists || overwriteExisting)
             {

--- a/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
+++ b/test/CloudModelGenerator.Tests/CodeGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace CloudModelGenerator.Tests
 {
     public class CodeGeneratorTests
     {
-        private readonly string TEMP_DIR = Path.GetTempPath() + "/CodeGeneratorTests/";
+        private readonly string TEMP_DIR = Path.Combine(Path.GetTempPath(), "CodeGeneratorTests");
 
         public CodeGeneratorTests()
         {

--- a/test/CloudModelGenerator.Tests/ProgramTests.cs
+++ b/test/CloudModelGenerator.Tests/ProgramTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.CommandLine;
+using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace CloudModelGenerator.Tests
@@ -24,6 +26,20 @@ namespace CloudModelGenerator.Tests
 
             var options = Program.CreateCodeGeneratorOptions(preparedSyntax);
             Assert.Equal("./", options.OutputDir);
+        }
+
+        [Fact]
+        public void CreateCodeGeneratorOptions_OutputSetInParameters_OuputDirHasCustomValue()
+        {
+            string expectedOutputDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            ArgumentSyntax preparedSyntax = Program.Parse(new string[]
+            {
+                "--projectid", "00000000-0000-0000-0000-000000000001",
+                "--outputdir", expectedOutputDir
+            });
+
+            var options = Program.CreateCodeGeneratorOptions(preparedSyntax);
+            Assert.Equal(expectedOutputDir, options.OutputDir);
         }
     }
 }


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #76 

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
  1 Run the generator on macOS while specifying a full path as its outputDir.