### PR TITLE
Setup the global tool

### DIFF
--- a/src/CloudModelGenerator/CloudModelGenerator.csproj
+++ b/src/CloudModelGenerator/CloudModelGenerator.csproj
@@ -7,7 +7,6 @@
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81</AssetTargetFallback>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILLink.Tasks" Version="0.1.4-preview-981901" />
     <PackageReference Include="KenticoCloud.Delivery" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #73 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

The changes are mainly done to AppVeyor configuration, sugestion can be found [here](https://gist.github.com/matus12/975fc17b552f329c1a6495acdabfe392/revisions#diff-180360612c6b8c4ed830919bbb4dd459). I have included the `<PackAsTool>` from .csproj only in the build proces so the project can be still built locally for specific runtime without any modification of the .csproj file. Now there is one more artifact created every build in the AppVeyor - a NuGet package that can be installed as a .NET Core global tool. 