### PR TITLE
Fix #87 - Update to KenticoCloud.Delivery v10.0.0

### DIFF
--- a/src/CloudModelGenerator/CloudModelGenerator.csproj
+++ b/src/CloudModelGenerator/CloudModelGenerator.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="KenticoCloud.Delivery" Version="8.0.0" />
+    <PackageReference Include="KenticoCloud.Delivery" Version="10.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/src/CloudModelGenerator/TypeProviderCodeGenerator.cs
+++ b/src/CloudModelGenerator/TypeProviderCodeGenerator.cs
@@ -60,7 +60,7 @@ using KenticoCloud.Delivery;
 
 namespace {_namespace}
 {{
-    public class {CLASS_NAME} : ICodeFirstTypeProvider
+    public class {CLASS_NAME} : ITypeProvider
     {{
         private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
         {{

--- a/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
+++ b/test/CloudModelGenerator.Tests/Assets/CustomTypeProvider_CompiledCode.txt
@@ -5,7 +5,7 @@ using KenticoCloud.Delivery;
 
 namespace KenticoCloudModels
 {
-	public class CustomTypeProvider : ICodeFirstTypeProvider
+	public class CustomTypeProvider : ITypeProvider
 	{
 		private static readonly Dictionary<Type, string> _codenames = new Dictionary<Type, string>
 		{


### PR DESCRIPTION
### Motivation

Fix #87 

Warning: 
This is a breaking update as it will not be compatible with KenticoCloud.Delivery < 10.0.0. 
How do you think to manage that? 
Do we have to add a -v 10 parameter or something?

Thanks a lot! 

_Gerfaut_